### PR TITLE
Clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,10 @@ RUN \
  echo "**** Installing runtime packages ****" && \
  apk add --no-cache \
 	curl \
-	sudo \
 	php7 \
-	curl \
 	php7-curl \
-	php7-sqlite3
+	php7-sqlite3 \
+	sudo
 RUN \
  echo "**** Installing BarcodeBuddy ****" && \
  mkdir -p /app/bbuddy && \


### PR DESCRIPTION
Remove extraneous `curl` from install, reorder dependencies in alphabetical order to keep things simple and prevent future duplicates.